### PR TITLE
Change list command to display either student or task list panel, changed UI

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -53,6 +54,16 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
+
+        // Set displayFieldsList if there is a list of params specified
+        // But not updating UI?
+        String[] displayParams = commandResult.getDisplayParams(); // array of strings eg. ["phone", "subjects"]
+        // String[] array = new String[] {"phone", "email", "address", "tags", "subjects"};
+        System.out.println(Arrays.toString(displayParams));
+        setDisplayedFieldsList(displayParams);
+        if (displayParams.length != 0) {
+            setDisplayedFieldsList(displayParams);
+        }
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -19,13 +19,25 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The panel to be active **/
+    private final String panel;
+
+    /** The parameters on what to display for student details **/
+    private final String[] displayParams;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, String panel, String[] displayParams) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.panel = panel;
+        this.displayParams = displayParams;
+    }
+
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this(feedbackToUser, showHelp, exit, "", new String[0]);
     }
 
     /**
@@ -33,7 +45,19 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, "", new String[0]);
+    }
+
+    public CommandResult(String feedbackToUser, String[] displayParams) {
+        this(feedbackToUser, false, false, "", displayParams);
+    }
+
+    public CommandResult(String feedbackToUser, String panel) {
+        this(feedbackToUser, false, false, panel, new String[0]);
+    }
+
+    public CommandResult(String feedbackToUser, String panel, String[] displayParams) {
+        this(feedbackToUser, false, false, panel, displayParams);
     }
 
     public String getFeedbackToUser() {
@@ -46,6 +70,14 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public String getPanel() {
+        return panel;
+    }
+
+    public String[] getDisplayParams() {
+        return displayParams;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,7 +3,10 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.Objects;
+
 import seedu.address.model.Model;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Lists all persons in the address book to the user.
@@ -12,13 +15,38 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static String MESSAGE_SUCCESS = "Showing list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays the specified list, which can be a "
+            + "student list, schedule list, task list. Default command without "
+            + "keywords displays the student list.\n"
+            + "Parameters: [KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " tasks";
+
+    private final String panel;
+    private final String[] displayParams;
+
+    public ListCommand(String panel, String[] displayParams) {
+        this.panel = panel;
+        this.displayParams = displayParams;
+    }
+
+    public ListCommand() {
+        this("", new String[0]);
+    }
+
+    public ListCommand(String panel) {
+        this(panel, new String[0]);
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (panel.equals("")) {
+            return new CommandResult(MESSAGE_SUCCESS, displayParams);
+        } else {
+            return new CommandResult(MESSAGE_SUCCESS, panel, displayParams);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,10 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.Objects;
-
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Lists all persons in the address book to the user.
@@ -15,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static String MESSAGE_SUCCESS = "Showing list";
+    public static final String MESSAGE_SUCCESS = "Showing list";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays the specified list, which can be a "
             + "student list, schedule list, task list. Default command without "
@@ -26,6 +23,12 @@ public class ListCommand extends Command {
     private final String panel;
     private final String[] displayParams;
 
+    /**
+     * Creates a list command.
+     *
+     * @param panel Name of the panel to display.
+     * @param displayParams Array of strings specifying details to display for each student.
+     */
     public ListCommand(String panel, String[] displayParams) {
         this.panel = panel;
         this.displayParams = displayParams;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -69,7 +69,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        String[] keywords = trimmedArgs.split("\\s+");
+
+        switch (keywords[0]) {
+        case "":
+        case "STUDENTS":
+            System.out.println("display students list");
+            String[] displayParams = Arrays.copyOfRange(keywords, 1, keywords.length);
+            return new ListCommand("STUDENTS", displayParams);
+
+        case "TASKS":
+            System.out.println("display task list");
+            return new ListCommand("TASKS");
+
+        default:
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+
+
+//        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -37,8 +37,6 @@ public class ListCommandParser implements Parser<ListCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
 
-
-//        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Subject.java
+++ b/src/main/java/seedu/address/model/person/Subject.java
@@ -19,11 +19,11 @@ public class Subject {
     private String colour;
     // useful resource: https://www.w3schools.com/tags/ref_colornames.asp for colours
     private HashMap<String, String> subjectToColourMap = new HashMap<String, String>() {{
-            put("MATHEMATICS", "red");
-            put("PHYSICS", "yellow");
-            put("BIOLOGY", "green");
-            put("CHEMISTRY", "lightBlue");
-            put("ENGLISH", "orange");
+            put("MATHEMATICS", "FireBrick");
+            put("PHYSICS", "Chocolate");
+            put("BIOLOGY", "ForestGreen");
+            put("CHEMISTRY", "DarkCyan");
+            put("ENGLISH", "SaddleBrown");
             put("NONE", "invalid");
         }};
 

--- a/src/main/java/seedu/address/ui/ColoredTextEntry.java
+++ b/src/main/java/seedu/address/ui/ColoredTextEntry.java
@@ -18,13 +18,13 @@ public class ColoredTextEntry extends StackPane {
      */
     public ColoredTextEntry(String text, String color) {
         Text textNode = new Text(text);
-        textNode.setFont(Font.font("Verdana", FontWeight.BOLD, 12));
-        Rectangle rectangle = new Rectangle(textNode.getLayoutBounds().getWidth() + 10,
+        textNode.setFont(Font.font("Segoe UI Semibold", FontWeight.BOLD, 10));
+        textNode.setFill(Color.WHITE);
+        Rectangle rectangle = new Rectangle(textNode.getLayoutBounds().getWidth() + 15,
                 textNode.getLayoutBounds().getHeight() + 10);
         rectangle.setArcWidth(20); // Customize the arc width to make it curved.
         rectangle.setArcHeight(20); // Customize the arc height to make it curved.
         rectangle.setFill(Color.web(color));
-
         getChildren().addAll(rectangle, textNode);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -9,6 +10,7 @@ import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -32,8 +34,12 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private TaskListPanel taskListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+
+    /** Panel currently displayed, default is students panel**/
+    private String activePanel = "STUDENTS";
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -42,7 +48,14 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
+    private VBox personList;
+    @FXML
     private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private VBox taskList;
+    @FXML
+    private StackPane taskListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -113,6 +126,11 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
+        taskListPanel = new TaskListPanel(logic);
+        taskListPanelPlaceholder.getChildren().add(taskListPanel.getRoot());
+        taskList.setVisible(false);
+        taskList.setManaged(false);
+
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
@@ -121,6 +139,25 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+    }
+
+    void hidePanels() {
+        personList.setVisible(false);
+        personList.setManaged(false);
+        taskList.setVisible(false);
+        taskList.setManaged(false);
+    }
+
+    void setTaskListPanel() {
+        taskList.setVisible(true);
+        taskList.setManaged(true);
+        activePanel = "TASKS";
+    }
+
+    void setPersonListPanel() {
+        personList.setVisible(true);
+        personList.setManaged(true);
+        activePanel = "STUDENTS";
     }
 
     /**
@@ -184,6 +221,29 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            System.out.println("panel is " + commandResult.getPanel());
+            if (commandResult.getPanel() != "") {
+                String newPanel = commandResult.getPanel();
+                System.out.println("show panel '" + newPanel+"'");
+                if (!newPanel.equals(activePanel)) {
+                    hidePanels();
+                    switch (newPanel) {
+                    case "TASKS":
+                        setTaskListPanel();
+                        break;
+                    case "STUDENTS":
+                        setPersonListPanel();
+                        break;
+                    default:
+                        System.out.println("unknown panel asked for");
+                        break;
+                    }
+
+                }
+            } else {
+                System.out.println("empty chosen panel");
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,6 +1,5 @@
 package seedu.address.ui;
 
-import java.util.Objects;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -223,10 +222,8 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            System.out.println("panel is " + commandResult.getPanel());
             if (commandResult.getPanel() != "") {
                 String newPanel = commandResult.getPanel();
-                System.out.println("show panel '" + newPanel+"'");
                 if (!newPanel.equals(activePanel)) {
                     hidePanels();
                     switch (newPanel) {

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -3,7 +3,6 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
@@ -28,25 +27,6 @@ public class TaskListPanel extends UiPart<Region> {
     public TaskListPanel(Logic logic) {
         super(FXML);
         this.logic = logic;
-//        personListView.setItems(logic.getFilteredPersonList());
-//        personListView.setCellFactory(listView -> new PersonListViewCell());
     }
-
-    /**
-     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
-     */
-//    class PersonListViewCell extends ListCell<Person> {
-//        @Override
-//        protected void updateItem(Person person, boolean empty) {
-//            super.updateItem(person, empty);
-//
-//            if (empty || person == null) {
-//                setGraphic(null);
-//                setText(null);
-//            } else {
-//                setGraphic(new PersonCard(person, getIndex() + 1, logic.getDisplayedFieldsList()).getRoot());
-//            }
-//        }
-//    }
 
 }

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -1,0 +1,52 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Logic;
+import seedu.address.model.person.Person;
+
+/**
+ * Panel containing the list of tasks.
+ */
+public class TaskListPanel extends UiPart<Region> {
+    private static final String FXML = "TaskListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(TaskListPanel.class);
+
+    private Logic logic;
+
+    @FXML
+    private ListView<Person> taskListView;
+
+    /**
+     * Creates a {@code TaskListPanel} with the given {@code ObservableList}.
+     */
+    public TaskListPanel(Logic logic) {
+        super(FXML);
+        this.logic = logic;
+//        personListView.setItems(logic.getFilteredPersonList());
+//        personListView.setCellFactory(listView -> new PersonListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
+     */
+//    class PersonListViewCell extends ListCell<Person> {
+//        @Override
+//        protected void updateItem(Person person, boolean empty) {
+//            super.updateItem(person, empty);
+//
+//            if (empty || person == null) {
+//                setGraphic(null);
+//                setText(null);
+//            } else {
+//                setGraphic(new PersonCard(person, getIndex() + 1, logic.getDisplayedFieldsList()).getRoot());
+//            }
+//        }
+//    }
+
+}

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -2,8 +2,11 @@
 
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.text.Font?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..." style="-fx-border-width: 0 0 1px 0;">
+      <font>
+         <Font name="Segoe UI" size="12.0" />
+      </font></TextField>
 </StackPane>
-

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,6 +1,6 @@
 .background {
-    -fx-background-color: derive(#1d1d1d, 20%);
-    background-color: #383838; /* Used in the default.html file */
+    -fx-background-color: #1B1828;
+    background-color: #1B1828; /* Used in the default.html file */
 }
 
 .label {
@@ -90,21 +90,25 @@
 .list-view {
     -fx-background-insets: 0;
     -fx-padding: 0;
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: #231F31;
 }
 
 .list-cell {
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap : 0;
-    -fx-padding: 0 0 0 0;
+    -fx-padding: 4;
+    /*-fx-background-radius: 25px;*/
+    -fx-background-color: #231F31;
+    -fx-border-width: 4px 0px;
+    -fx-border-color: #231F31;
 }
 
 .list-cell:filled:even {
-    -fx-background-color: #3c3e3f;
+    -fx-background-color: #322D46;
 }
 
 .list-cell:filled:odd {
-    -fx-background-color: #515658;
+    -fx-background-color: #322D46;
 }
 
 .list-cell:filled:selected {
@@ -112,8 +116,9 @@
 }
 
 .list-cell:filled:selected #cardPane {
-    -fx-border-color: #3e7b91;
+    /*-fx-border-color: #3e7b91;
     -fx-border-width: 1;
+    -fx-border-radius: 10pt;*/
 }
 
 .list-cell .label {
@@ -133,11 +138,11 @@
 }
 
 .stack-pane {
-     -fx-background-color: derive(#1d1d1d, 20%);
+     -fx-background-color: #322D46;
 }
 
 .pane-with-border {
-     -fx-background-color: derive(#1d1d1d, 20%);
+     -fx-background-color: #1B1828;
      -fx-border-color: derive(#1d1d1d, 10%);
      -fx-border-top-width: 1px;
 }
@@ -147,7 +152,7 @@
 }
 
 .result-display {
-    -fx-background-color: transparent;
+    -fx-background-color: #231F31;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
     -fx-text-fill: white;
@@ -197,10 +202,11 @@
 }
 
 .menu-bar .label {
-    -fx-font-size: 14pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-size: 12pt;
+    -fx-font-family: "Segoe UI Semibold";
     -fx-text-fill: white;
     -fx-opacity: 0.9;
+    -fx-padding: 2pt;
 }
 
 .menu .left-container {
@@ -282,12 +288,13 @@
 }
 
 .scroll-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: #231F31;
+    -fx-padding: 0 0 0 10;
 }
 
 .scroll-bar .thumb {
-    -fx-background-color: derive(#1d1d1d, 50%);
-    -fx-background-insets: 3;
+    -fx-background-color: #73707F;
+    -fx-background-insets: 4;
 }
 
 .scroll-bar .increment-button, .scroll-bar .decrement-button {
@@ -333,7 +340,7 @@
 }
 
 #resultDisplay .content {
-    -fx-background-color: transparent, #383838, transparent, #383838;
+    -fx-background-color: #231F31;
     -fx-background-radius: 0;
 }
 
@@ -349,4 +356,12 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+.panel-label {
+    -fx-font-size: 14pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: white;
+    -fx-opacity: 1;
+    -fx-padding: 0 0 2pt 0;
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,13 +6,12 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+<fx:root minHeight="600.0" minWidth="450.0" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -23,8 +22,8 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
+      <VBox style="-fx-background-color: #231F31; -fx-border-width: 0;">
+        <MenuBar fx:id="menuBar" style="-fx-background-color: #1B1828;" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
           </Menu>
@@ -33,27 +32,39 @@
           </Menu>
         </MenuBar>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+        <StackPane fx:id="commandBoxPlaceholder" style="-fx-background-color: #322D46; -fx-border-width: 0;" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+        <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" style="-fx-background-color: #231F31; -fx-border-color: #1B1828;" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <VBox fx:id="personList" minWidth="340" prefWidth="340" style="-fx-background-color: #231F31; -fx-border-width: 0px;" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
           <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
+            <Insets bottom="10" left="10" right="10" top="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+               <VBox.margin>
+                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+               </VBox.margin>
         </VBox>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+        <VBox fx:id="taskList" minWidth="340" prefWidth="340" style="-fx-background-color: #231F31; -fx-border-width: 0;" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets bottom="10" left="10" right="10" top="10" />
+          </padding>
+          <StackPane fx:id="taskListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+               <VBox.margin>
+                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+               </VBox.margin>
+        </VBox>
+
+        <StackPane fx:id="statusbarPlaceholder" style="-fx-border-width: 0;" VBox.vgrow="NEVER" />
       </VBox>
     </Scene>
   </scene>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,27 +7,31 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox fx:id = "fields" alignment="CENTER_LEFT" minHeight="17" GridPane.columnIndex="0">
+    <VBox fx:id="fields" alignment="CENTER_LEFT" minHeight="17" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
+      <HBox alignment="CENTER_LEFT" spacing="5">
+        <Label fx:id="id" styleClass="cell_big_label" textFill="WHITE">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" textFill="WHITE" />
       </HBox>
       <FlowPane fx:id="tags" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+<VBox xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+   <Label styleClass="panel-label" text="Students">
+      <VBox.margin>
+         <Insets bottom="3.0" />
+      </VBox.margin></Label>
+  <ListView fx:id="personListView" VBox.vgrow="ALWAYS">
+      <VBox.margin>
+         <Insets bottom="10.0" />
+      </VBox.margin>
+      <opaqueInsets>
+         <Insets />
+      </opaqueInsets></ListView>
 </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+<StackPane fx:id="placeHolder" style="-fx-background-color: #231F31; -fx-border-color: #231F31; -fx-border-width: 0;" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+  <TextArea fx:id="resultDisplay" editable="false" style="-fx-background-color: #231F31; -fx-border-color: #231F31; -fx-border-width: 0;" styleClass="result-display" />
 </StackPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -3,10 +3,14 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 
-<GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane style="-fx-background-color: #322D46;" styleClass="status-bar" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
   </columnConstraints>
   <Label fx:id="saveLocationStatus" />
+   <rowConstraints>
+      <RowConstraints />
+   </rowConstraints>
 </GridPane>

--- a/src/main/resources/view/TaskListPanel.fxml
+++ b/src/main/resources/view/TaskListPanel.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+    <Label styleClass="panel-label" text="Tasks" />
+    <ListView fx:id="taskListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,7 +85,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " STUDENTS") instanceof ListCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/SubjectTest.java
+++ b/src/test/java/seedu/address/model/person/SubjectTest.java
@@ -32,15 +32,15 @@ class SubjectTest {
             Subject none = new Subject("NONE");
             assertEquals(none.getColour(), "invalid");
             Subject maths = new Subject("MATHEMATICS");
-            assertEquals(maths.getColour(), "red");
+            assertEquals(maths.getColour(), "FireBrick");
             Subject physics = new Subject("PHYSICS");
-            assertEquals(physics.getColour(), "yellow");
+            assertEquals(physics.getColour(), "Chocolate");
             Subject biology = new Subject("BIOLOGY");
-            assertEquals(biology.getColour(), "green");
+            assertEquals(biology.getColour(), "ForestGreen");
             Subject chemistry = new Subject("CHEMISTRY");
-            assertEquals(chemistry.getColour(), "lightBlue");
+            assertEquals(chemistry.getColour(), "DarkCyan");
             Subject english = new Subject("ENGLISH");
-            assertEquals(english.getColour(), "orange");
+            assertEquals(english.getColour(), "SaddleBrown");
         } catch (Exception e) {
             assert false;
         }


### PR DESCRIPTION
Firstly there are some UI changes, with a color scheme redesign as shown:
![image](https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/67725787/e2d00b63-84c7-4729-9e70-23130481bef5)


There is a need to display different lists, but no such command to do so.

List command now takes in an optional keyword to denote what type of list to show. When there are no keywords, the STUDENTS list will be shown by default.
Currently the only lists available are the `STUDENTS` and `TASKS` list.

eg. `list` and `list STUDENTS` will display the STUDENTS list, which is the same screenshot as above.

Providing more keywords will specify what details to show per student.
eg. `list STUDENTS phone email subjects` will return an array of ["phone", "email", "subjects"] that should be set using Logic Manager's `setDisplayedListFields` method.
** However, there is a known issue:
The Logic Manager class's `execute` method has a section that tries to change the displayedFieldsList, but doesn't update the UI when using the corresponding `setDisplayedListFields` method.

`list TASKS` will display the TASKS list as shown below:
![image](https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/67725787/c631e269-677c-4a4c-8fa3-e4f0ef0401fd)

Also, commands that act on the STUDENTS list will still work while in the TASKS list (or any other lists)

