### PR TITLE
Modify Find Command to work with students and lessons

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX = "The lesson index provided is invalid";
 
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_LESSONS_LISTED_OVERVIEW = "%1$d lessons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -66,13 +66,13 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return predicate.equals(otherFindCommand.predicate);
+        return trimmedArgs.equals(otherFindCommand.trimmedArgs);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("predicate", predicate)
+                .add("trimmed args", trimmedArgs)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,36 +2,56 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.lessons.Lesson;
+import seedu.address.model.lessons.LessonContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons or lessons in app whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons or lesson whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " alice";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private Predicate predicate;
+    private final String trimmedArgs;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(String trimmedArgs) {
+        this.trimmedArgs = trimmedArgs;
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        switch (model.getState()) {
+        case STUDENT:
+            predicate = new NameContainsKeywordsPredicate(trimmedArgs);
+            model.updateFilteredPersonList(predicate);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        case SCHEDULE:
+            predicate = new LessonContainsKeywordsPredicate(trimmedArgs);
+            model.updateFilteredScheduleList(predicate);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_LESSONS_LISTED_OVERVIEW, model.getFilteredScheduleList().size()));
+        default:
+            throw new CommandException(Messages.MESSAGE_UNKNOWN_COMMAND);
+        }
+
+
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,10 +8,8 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.lessons.Lesson;
 import seedu.address.model.lessons.LessonContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons or lessons in app whose name contains any of the argument keywords.
@@ -21,8 +19,8 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons or lesson whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons or lesson whose names contain "
+            + "any ofthe specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice";
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -41,7 +41,7 @@ public class ListCommand extends Command {
     }
 
     public ListCommand() {
-        this(State.NONE, new String[0]);
+        this(State.SCHEDULE, new String[0]);
     }
 
     public ListCommand(State state) {
@@ -51,15 +51,8 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-
-        switch (model.getState()) {
-        case STUDENT:
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            break;
-        case SCHEDULE:
-            model.updateFilteredScheduleList(PREDICATE_SHOW_ALL_LESSONS);
-            break;
-        }
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredScheduleList(PREDICATE_SHOW_ALL_LESSONS);
         if (model.sameState(state)) {
             return new CommandResult(MESSAGE_SUCCESS, displayParams);
         } else {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_LESSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Arrays;
@@ -50,7 +51,15 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        switch (model.getState()) {
+        case STUDENT:
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            break;
+        case SCHEDULE:
+            model.updateFilteredScheduleList(PREDICATE_SHOW_ALL_LESSONS);
+            break;
+        }
         if (model.sameState(state)) {
             return new CommandResult(MESSAGE_SUCCESS, displayParams);
         } else {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -23,7 +23,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(trimmedArgs));
+        return new FindCommand(trimmedArgs);
     }
 
 }

--- a/src/main/java/seedu/address/model/lessons/Lesson.java
+++ b/src/main/java/seedu/address/model/lessons/Lesson.java
@@ -17,6 +17,7 @@ public class Lesson extends ListEntry<Lesson> {
     public static final Lesson DEFAULT_LESSON = new Lesson();
     private Time start;
     private Time end;
+    private Name name;
     // Data fields
     private Subject subject;
     private Day day;
@@ -102,6 +103,14 @@ public class Lesson extends ListEntry<Lesson> {
      * Else, the date will be returned as: [start date] - [end date]
      * @return
      */
+    public String getLessonNameStr() {
+        return name.toString();
+    }
+
+    /**
+     * Gets the name of a lesson.
+     * @return
+     */
     public String getLessonDateStr() {
         return day.toString();
     }
@@ -178,6 +187,19 @@ public class Lesson extends ListEntry<Lesson> {
 
     public TaskList getTaskList() {
         return taskList;
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public void setName(Name name) {
+        this.name = name;
+    }
+    public void setNameIfNotDefault(Name name) {
+        if (name != null && !name.equals(Name.DEFAULT_NAME)) {
+            setName(name);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/lessons/LessonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/lessons/LessonContainsKeywordsPredicate.java
@@ -1,0 +1,42 @@
+package seedu.address.model.lessons;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Lesson}'s {@code Name} matches any of the keywords given.
+ */
+public class LessonContainsKeywordsPredicate implements Predicate<Lesson> {
+    private final String keyword;
+
+    public LessonContainsKeywordsPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Lesson lesson) {
+        return StringUtil.containsWordIgnoreCase(lesson.getLessonNameStr(), keyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof LessonContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        LessonContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (LessonContainsKeywordsPredicate) other;
+        return keyword.equals(otherNameContainsKeywordsPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keyword", keyword).toString();
+    }
+}

--- a/src/main/java/seedu/address/ui/LessonCard.java
+++ b/src/main/java/seedu/address/ui/LessonCard.java
@@ -29,7 +29,9 @@ public class LessonCard extends UiPart<Region> {
     @FXML
     private HBox cardPane;
     @FXML
-    private Label overview;
+    private Label name;
+    @FXML
+    private Label date;
     @FXML
     private Label id;
     @FXML
@@ -43,7 +45,8 @@ public class LessonCard extends UiPart<Region> {
         super(FXML);
         this.lesson = lesson;
         id.setText(displayedIndex + ". ");
-        overview.setText(lesson.getLessonDateStr());
+        name.setText(lesson.getLessonNameStr());
+        date.setText(lesson.getLessonDateStr());
         duration.setText(lesson.getLessonDurationStr());
         for (String field : displayFields) {
             // TODO: Implement the schedule detail

--- a/src/main/java/seedu/address/ui/LessonDetailListPanel.java
+++ b/src/main/java/seedu/address/ui/LessonDetailListPanel.java
@@ -28,6 +28,9 @@ public class LessonDetailListPanel extends UiPart<Region> {
     private TextField date;
 
     @FXML
+    private TextField lessonName;
+
+    @FXML
     private TextField startTime;
 
     @FXML
@@ -60,6 +63,7 @@ public class LessonDetailListPanel extends UiPart<Region> {
      * @param lesson The lesson whose details are to be shown.
      */
     public void setLessonDetails(Lesson lesson) {
+        lessonName.setText(lesson.getLessonNameStr());
         date.setText(lesson.getLessonDateStr());
         startTime.setText(lesson.getStart().toString());
         endTime.setText(lesson.getEnd().toString());

--- a/src/main/resources/view/LessonDetailListPanel.fxml
+++ b/src/main/resources/view/LessonDetailListPanel.fxml
@@ -11,7 +11,6 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<?import javafx.scene.control.ListView?>
 <ScrollPane fitToHeight="true" fitToWidth="true" style="-fx-background: #231F31; -fx-background-radius: 10; -fx-border-width: 0; -fx-background-color: transparent;" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
    <content>
       <AnchorPane style="-fx-background-color: #322D46; -fx-background-radius: 10; -fx-border-width: 0;">
@@ -19,6 +18,12 @@
             <Label layoutX="10.0" layoutY="10.0" style="-fx-text-fill: white;" styleClass="panel-label" text="Lesson Details" />
             <VBox layoutX="20.0" layoutY="58.0" prefHeight="200.0" prefWidth="320.0" spacing="10.0" AnchorPane.bottomAnchor="48.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="48.0">
                <children>
+                  <HBox alignment="CENTER_LEFT" layoutX="15.0" layoutY="50.0" prefHeight="25.0" prefWidth="120.0">
+                     <children>
+                        <Label style="-fx-text-fill: white;" text="Name:" />
+                        <TextField fx:id="lessonName" alignment="BOTTOM_LEFT" editable="false" prefHeight="25.0" prefWidth="120.0" style="-fx-background-color: transparent; -fx-text-fill: white;" text="\$lessonName" HBox.hgrow="ALWAYS" />
+                     </children>
+                  </HBox>
                   <HBox alignment="CENTER_LEFT" prefHeight="25.0" prefWidth="120.0">
                      <children>
                         <ImageView fitHeight="21.0" fitWidth="21.0" pickOnBounds="true" preserveRatio="true">

--- a/src/main/resources/view/LessonListCard.fxml
+++ b/src/main/resources/view/LessonListCard.fxml
@@ -26,13 +26,18 @@
               <Region fx:constant="USE_PREF_SIZE" />
             </minWidth>
           </Label>
-          <Label fx:id="overview" styleClass="cell_big_label" textFill="WHITE">
+          <Label fx:id="name" styleClass="cell_big_label" textFill="WHITE">
             <minWidth>
               <!-- Ensures that the label text is never truncated -->
               <Region fx:constant="USE_PREF_SIZE" />
             </minWidth>
           </Label>
         </HBox>
+            <Label fx:id="date" layoutX="10.0" layoutY="32.0" styleClass="cell_small_label" textFill="WHITE">
+               <minWidth>
+                  <Region fx:constant="USE_PREF_SIZE" />
+               </minWidth>
+            </Label>
         <Label fx:id="duration" styleClass="cell_small_label" textFill="WHITE">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_LESSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalLessons.getTypicalScheduleList;
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.lessons.LessonContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.state.State;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -26,19 +29,17 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate("first");
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate("second");
+        String firstTrimmedArg = "first";
+        String secondTrimmedArg = "second";
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstTrimmedArg);
+        FindCommand findSecondCommand = new FindCommand(secondTrimmedArg);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstTrimmedArg);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -54,24 +55,64 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_allPersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 7);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        String trimmedArgs = " ";
+        FindCommand command = new FindCommand(trimmedArgs);
+        expectedModel.setState(State.STUDENT);
+        model.setState(State.STUDENT);
+        expectedModel.updateFilteredPersonList(new NameContainsKeywordsPredicate(trimmedArgs));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_zeroKeywords_allLessonsFound() {
+        String expectedMessage = String.format(MESSAGE_LESSONS_LISTED_OVERVIEW, 5);
+        String trimmedArgs = " ";
+        FindCommand command = new FindCommand(trimmedArgs);
+        expectedModel.setState(State.SCHEDULE);
+        model.setState(State.SCHEDULE);
+        expectedModel.updateFilteredScheduleList(new LessonContainsKeywordsPredicate(trimmedArgs));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_searchOneLesson() {
+        String expectedMessage = String.format(MESSAGE_LESSONS_LISTED_OVERVIEW, 1);
+        String trimmedArgs = "random";
+        FindCommand command = new FindCommand(trimmedArgs);
+        expectedModel.setState(State.SCHEDULE);
+        model.setState(State.SCHEDULE);
+        expectedModel.updateFilteredScheduleList(new LessonContainsKeywordsPredicate(trimmedArgs));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_searchNotFoundLesson() {
+        String expectedMessage = String.format(MESSAGE_LESSONS_LISTED_OVERVIEW, 0);
+        String trimmedArgs = "lesson does not exist";
+        FindCommand command = new FindCommand(trimmedArgs);
+        expectedModel.setState(State.SCHEDULE);
+        model.setState(State.SCHEDULE);
+        expectedModel.updateFilteredScheduleList(new LessonContainsKeywordsPredicate(trimmedArgs));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_searchMultipleLessons() {
+        String expectedMessage = String.format(MESSAGE_LESSONS_LISTED_OVERVIEW, 4);
+        String trimmedArgs = "lesson";
+        FindCommand command = new FindCommand(trimmedArgs);
+        expectedModel.setState(State.SCHEDULE);
+        model.setState(State.SCHEDULE);
+        expectedModel.updateFilteredScheduleList(new LessonContainsKeywordsPredicate(trimmedArgs));
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate("keyword");
-        FindCommand findCommand = new FindCommand(predicate);
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        String trimmedArgs = "keyword";
+        FindCommand findCommand = new FindCommand(trimmedArgs);
+        String expected = FindCommand.class.getCanonicalName() + "{trimmed args=" + trimmedArgs + "}";
         assertEquals(expected, findCommand.toString());
     }
 
-    /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
-     */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(userInput);
-    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,7 +19,6 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class AddressBookParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -73,7 +73,7 @@ public class AddressBookParserTest {
         String keyword = "foo";
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keyword);
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keyword)), command);
+        assertEquals(new FindCommand(keyword), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -22,7 +22,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate("Alice"));
+                new FindCommand("Alice");
         assertParseSuccess(parser, "Alice", expectedFindCommand);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalLessons.java
+++ b/src/test/java/seedu/address/testutil/TypicalLessons.java
@@ -38,7 +38,9 @@ public class TypicalLessons {
             return new ArrayList<>(Arrays.asList(
                     new Lesson("lesson 1", "14:30", "16:30", "2022/10/10", "MATHEMATICS", taskList),
                     new Lesson("lesson 2", "14:30", "16:30", "2022/10/20", "BIOLOGY", taskList),
-                    new Lesson("lesson 3", "10:30", "12:30", "2022/11/20", "MATHEMATICS", taskList)
+                    new Lesson("lesson 3", "10:30", "12:30", "2022/11/20", "MATHEMATICS", taskList),
+                    new Lesson("some lesson", "11:30", "10:30", "2022/12/20", "BIOLOGY", taskList),
+                    new Lesson("random name", "09:30", "10:30", "2022/11/21", "PHYSICS", taskList)
             ));
         } catch (ParseException e) {
             return new ArrayList<>();


### PR DESCRIPTION
##  Modify Find Command
Find command now works with students and lessons
* Modify find command to allow for both finding student and lesson using the same command
* Constructor takes in a string of trimmed arguments instead of a predicate
* During execution, depending on the model state, the correct predicate is created, and command executes either filtering student of lesson
* Change equals method in find command to check against the trimmed args, since predicate is not initialised until execution
* Messages.java: Create new output message when finding lessons

## Find command testing
* Add extra typical lessons for testing purposes
* Change find command tests to use trimmed args instead of predicates
* Add test cases to search for one, none, and multiple lessons

## Edit LessonCard
* Create new field in fxml for lesson name, and controller class to set the name
![image](https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/67725787/e1b6ec7f-7a8b-4f0d-9d9b-bb5b08329e76)

## Display lesson name in lesson details
* Create new lesson name field in lesson detail panel
![image](https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/67725787/363b7598-a918-4c6c-9ff6-33e258d3e017)

## Bug fix with lesson names being reset to default name
* Lesson did not have a name, and cannot be used for display, also lesson name is saved as default name without getter
* Include name field, method to return name string for displaying, getter and setter for name

## Modify List Command
* Reset schedule list every time during list command
* Change list command to always remove filter past filter and give all persons and lessons when called