### PR TITLE
Add display of students in lesson in ui

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -69,7 +69,7 @@ public class MainApp extends Application {
 
         logic = new LogicManager(model, storage);
 
-        ui = new UiManager(logic);
+        ui = new UiManager(logic, model);
 
         model.linkUi(ui);
     }

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -42,7 +42,7 @@ public class AddPersonCommand extends Command {
             + PREFIX_SCHEDULE + "Monday 1200 1400 weekly";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Person with this name already exists in the address book";
 
     private final Person toAdd;
     private Lesson lesson = null;
@@ -67,7 +67,7 @@ public class AddPersonCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd)) {
+        if (model.hasPersonClashWith(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
         if (lesson != null) {

--- a/src/main/java/seedu/address/model/BiDirectionalMap.java
+++ b/src/main/java/seedu/address/model/BiDirectionalMap.java
@@ -31,6 +31,14 @@ public class BiDirectionalMap<T extends ListEntry<T>, P extends ListEntry<P>> {
     }
 
     /**
+     * Removes a key-value pair and its reverse from the map
+     */
+    public void removeMapping(T t, P p) {
+        forwardMap.get(t.getName()).remove(p.getName());
+        reverseMap.get(p.getName()).remove(t.getName());
+    }
+
+    /**
      * Returns the value associated with the key
      */
     public Name[] get(T t) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,14 +1,12 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.lessons.Task;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.state.State;
 import seedu.address.ui.Ui;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,12 +1,14 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.lessons.Task;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.state.State;
 import seedu.address.ui.Ui;
@@ -205,4 +207,8 @@ public interface Model {
     default BiDirectionalMap<Person, Lesson> getPersonLessonMap() {
         return null;
     }
+    void linkWith(Person person, Lesson lesson);
+    void unLinkWith(Person person, Lesson lesson);
+    String getLinkedPersonNameStr(Lesson lesson);
+    String getLinkedLessonNameStr(Person person);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -13,6 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.lessons.Task;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.state.State;
 import seedu.address.ui.Ui;
@@ -143,7 +145,6 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
         addressBook.setPerson(target, editedPerson);
         personToLessonMap.update(target, editedPerson);
-
     }
 
 
@@ -310,6 +311,21 @@ public class ModelManager implements Model {
 
     public BiDirectionalMap<Person, Lesson> getPersonLessonMap() {
         return personToLessonMap;
+    }
+
+    public void linkWith(Person person, Lesson lesson) {
+        personToLessonMap.addMapping(person, lesson);
+    }
+    public void unLinkWith(Person person, Lesson lesson) {
+        personToLessonMap.removeMapping(person, lesson);
+    }
+    public String getLinkedPersonNameStr(Lesson lesson) {
+        return Arrays.stream(personToLessonMap.getReversed(lesson)).map(Name::toString)
+                .reduce((a, b) -> a + ", " + b).orElse("Not linked to any Students yet");
+    }
+    public String getLinkedLessonNameStr(Person person) {
+        return Arrays.stream(personToLessonMap.get(person)).map(Name::toString)
+                .reduce((a, b) -> a + ", " + b).orElse("Not linked to any Lessons yet");
     }
 
 }

--- a/src/main/java/seedu/address/ui/LessonCard.java
+++ b/src/main/java/seedu/address/ui/LessonCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 
 /**
@@ -41,7 +42,7 @@ public class LessonCard extends UiPart<Region> {
     /**
      * Creates a {@code LessonCard} with the given {@code Lesson} and index to display.
      */
-    public LessonCard(Lesson lesson, int displayedIndex, String[] displayFields) {
+    public LessonCard(Lesson lesson, int displayedIndex, String[] displayFields, Model model) {
         super(FXML);
         this.lesson = lesson;
         id.setText(displayedIndex + ". ");
@@ -50,7 +51,7 @@ public class LessonCard extends UiPart<Region> {
         duration.setText(lesson.getLessonDurationStr());
         for (String field : displayFields) {
             // TODO: Implement the schedule detail
-            LessonCardFieldBuilder.build(field, lesson, fields);
+            LessonCardFieldBuilder.build(field, lesson, fields, model);
         }
     }
 

--- a/src/main/java/seedu/address/ui/LessonCardFieldBuilder.java
+++ b/src/main/java/seedu/address/ui/LessonCardFieldBuilder.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 
 
@@ -15,13 +16,13 @@ public class LessonCardFieldBuilder {
      * @param lesson the lesson
      * @param fields the fields
      */
-    public static void build(String fieldName, Lesson lesson, VBox fields) {
+    public static void build(String fieldName, Lesson lesson, VBox fields, Model model) {
         switch (fieldName) {
         case "date":
             buildDate(lesson, fields);
             break;
         case "students":
-            buildStudents(lesson, fields);
+            buildStudents(lesson, fields, model);
             break;
         case "subjects":
             buildSubjects(lesson, fields);
@@ -38,8 +39,8 @@ public class LessonCardFieldBuilder {
         fields.getChildren().add(date);
     }
 
-    static void buildStudents(Lesson lesson, VBox fields) {
-        Label students = new Label(lesson.getStudentsStr());
+    static void buildStudents(Lesson lesson, VBox fields, Model model) {
+        Label students = new Label(model.getLinkedPersonNameStr(lesson));
         students.getStyleClass().add("cell_small_label");
         fields.getChildren().add(students);
     }

--- a/src/main/java/seedu/address/ui/LessonDetailListPanel.java
+++ b/src/main/java/seedu/address/ui/LessonDetailListPanel.java
@@ -11,6 +11,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.lessons.Task;
 
@@ -62,12 +63,12 @@ public class LessonDetailListPanel extends UiPart<Region> {
      *
      * @param lesson The lesson whose details are to be shown.
      */
-    public void setLessonDetails(Lesson lesson) {
+    public void setLessonDetails(Lesson lesson, Model model) {
         lessonName.setText(lesson.getLessonNameStr());
         date.setText(lesson.getLessonDateStr());
         startTime.setText(lesson.getStart().toString());
         endTime.setText(lesson.getEnd().toString());
-        students.setText(lesson.getStudentsStr());
+        students.setText(model.getLinkedPersonNameStr(lesson));
         subject.setText(lesson.getSubject().toString());
         //taskListView.setItems("to be implemented");
         //taskListView.setCellFactory(listView -> new LessonDetailListPanel.TaskListViewCell());

--- a/src/main/java/seedu/address/ui/LessonListPanel.java
+++ b/src/main/java/seedu/address/ui/LessonListPanel.java
@@ -11,6 +11,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 
 /**
@@ -21,6 +22,7 @@ public class LessonListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(LessonListPanel.class);
 
     private Logic logic;
+    private Model model;
     private BooleanProperty reRenderUi;
     @FXML
     private ListView<Lesson> scheduleListView;
@@ -28,9 +30,10 @@ public class LessonListPanel extends UiPart<Region> {
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public LessonListPanel(Logic logic) {
+    public LessonListPanel(Logic logic, Model model) {
         super(FXML);
         this.logic = logic;
+        this.model = model;
         this.reRenderUi = logic.getRefreshListUi(); // Connect to the logic manager's boolean flag
         scheduleListView.setItems(logic.getFilteredScheduleList());
         scheduleListView.setCellFactory(listView -> new ScheduleListViewCell());
@@ -60,7 +63,7 @@ public class LessonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new LessonCard(lesson, getIndex() + 1, logic.getDisplayedFieldsList()).getRoot());
+                setGraphic(new LessonCard(lesson, getIndex() + 1, logic.getDisplayedFieldsList(), model).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -19,6 +19,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.person.Person;
 import seedu.address.model.state.State;
@@ -35,6 +36,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
+    private Model model;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -85,12 +87,13 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
-    public MainWindow(Stage primaryStage, Logic logic) {
+    public MainWindow(Stage primaryStage, Logic logic, Model model) {
         super(FXML, primaryStage);
 
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
+        this.model = model;
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
@@ -145,7 +148,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        lessonListPanel = new LessonListPanel(logic);
+        lessonListPanel = new LessonListPanel(logic, model);
         scheduleListPanelPlaceholder.getChildren().add(lessonListPanel.getRoot());
 
         studentDetailListPanel = new StudentDetailListPanel(logic);
@@ -266,7 +269,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     public void handleShowPerson(Person person) {
         studentDetailList.setVisible(true);
-        studentDetailListPanel.setPersonDetails(person);
+        studentDetailListPanel.setPersonDetails(person, model);
     }
 
     /**
@@ -276,6 +279,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     public void handleShowLesson(Lesson lesson) {
         lessonDetailList.setVisible(true);
-        lessonDetailListPanel.setLessonDetails(lesson);
+        lessonDetailListPanel.setLessonDetails(lesson, model);
     }
 }

--- a/src/main/java/seedu/address/ui/StudentDetailListPanel.java
+++ b/src/main/java/seedu/address/ui/StudentDetailListPanel.java
@@ -42,6 +42,8 @@ public class StudentDetailListPanel extends UiPart<Region> {
 
     @FXML
     private TextField remark;
+    @FXML
+    private TextField lessons;
 
     /**
      * Creates a {@code StudentDetailListPanel} with the given {@code ObservableList}.
@@ -62,6 +64,7 @@ public class StudentDetailListPanel extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+        lessons.setText(model.getLinkedLessonNameStr(person));
         remark.setText(person.getRemark().value);
         // Clears the previous items in the FlowPane for Tags and Subjects
         tags.getChildren().clear();

--- a/src/main/java/seedu/address/ui/StudentDetailListPanel.java
+++ b/src/main/java/seedu/address/ui/StudentDetailListPanel.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
@@ -56,13 +57,12 @@ public class StudentDetailListPanel extends UiPart<Region> {
      *
      * @param person The person whose details are to be shown.
      */
-    public void setPersonDetails(Person person) {
+    public void setPersonDetails(Person person, Model model) {
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
         remark.setText(person.getRemark().value);
-
         // Clears the previous items in the FlowPane for Tags and Subjects
         tags.getChildren().clear();
         subjects.getChildren().clear();

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -11,6 +11,7 @@ import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
+import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.person.Person;
 
@@ -25,13 +26,15 @@ public class UiManager implements Ui {
     private static final String ICON_APPLICATION = "/images/tutormate32.png";
 
     private Logic logic;
+    private Model model;
     private MainWindow mainWindow;
 
     /**
      * Creates a {@code UiManager} with the given {@code Logic}.
      */
-    public UiManager(Logic logic) {
+    public UiManager(Logic logic, Model model) {
         this.logic = logic;
+        this.model = model;
     }
 
     @Override
@@ -42,7 +45,7 @@ public class UiManager implements Ui {
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
 
         try {
-            mainWindow = new MainWindow(primaryStage, logic);
+            mainWindow = new MainWindow(primaryStage, logic, model);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
 

--- a/src/main/resources/view/StudentDetailListPanel.fxml
+++ b/src/main/resources/view/StudentDetailListPanel.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextField?>
@@ -60,6 +61,15 @@
                   </HBox>
                   <FlowPane fx:id="tags" prefHeight="25.0" prefWidth="320.0" />
                   <FlowPane fx:id="subjects" prefHeight="25.0" prefWidth="320.0" />
+                  <HBox alignment="CENTER_LEFT" layoutX="10.0" layoutY="80.0" prefHeight="25.0" prefWidth="254.0">
+                     <children>
+                        <Label style="-fx-text-fill: white;" text="Lesson(s): " />
+                        <TextField fx:id="lessons" editable="false" style="-fx-background-color: transparent; -fx-text-fill: white;" text="\$students" HBox.hgrow="ALWAYS" />
+                     </children>
+                     <VBox.margin>
+                        <Insets />
+                     </VBox.margin>
+                  </HBox>
                   <HBox alignment="CENTER_LEFT" prefHeight="25.0" prefWidth="120.0">
                      <children>
                         <ImageView fitHeight="21.0" fitWidth="21.0" pickOnBounds="true" preserveRatio="true">

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -49,11 +49,10 @@ public class AddPersonCommandTest {
     }
 
     @Test
-    public void execute_duplicatePerson_throwsCommandException() {
+    public void execute_duplicatePerson_throwsCommandException() throws CommandException {
         Person validPerson = new PersonBuilder().build();
         AddPersonCommand addPersonCommand = new AddPersonCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
-
         assertThrows(CommandException.class,
                 AddPersonCommand.MESSAGE_DUPLICATE_PERSON, () -> addPersonCommand.execute(modelStub));
     }
@@ -248,6 +247,26 @@ public class AddPersonCommandTest {
         }
 
         @Override
+        public void linkWith(Person person, Lesson lesson) {
+
+        }
+
+        @Override
+        public void unLinkWith(Person person, Lesson lesson) {
+
+        }
+
+        @Override
+        public String getLinkedPersonNameStr(Lesson lesson) {
+            return null;
+        }
+
+        @Override
+        public String getLinkedLessonNameStr(Person person) {
+            return null;
+        }
+
+        @Override
         public boolean hasLessonClashWith(Lesson lesson) {
             throw new AssertionError("This method should not be called.");
         }
@@ -274,6 +293,10 @@ public class AddPersonCommandTest {
             requireNonNull(person);
             return this.person.isSamePerson(person);
         }
+        @Override
+        public Boolean hasPersonClashWith(Person person) {
+            return this.person.hasSameName(person);
+        }
     }
 
     /**
@@ -292,6 +315,10 @@ public class AddPersonCommandTest {
         public void addPerson(Person person) {
             requireNonNull(person);
             personsAdded.add(person);
+        }
+        @Override
+        public Boolean hasPersonClashWith(Person person) {
+            return personsAdded.stream().anyMatch(person::hasSameName);
         }
 
         @Override


### PR DESCRIPTION
Add the ui support for displaying name of linked students in a lesson.
When a lesson is not linked to any students, it should look like this:
<img width="731" alt="Screenshot 2023-10-31 at 20 42 12" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/4ce36d22-c347-4cb5-8414-947fa7835725">
When a lesson is linked to students, it look like this:
<img width="737" alt="Screenshot 2023-10-31 at 20 41 12" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/cede87a5-8a4a-4333-9fdc-743b96e57fb0">
Note, the command and parser for link is not ready yet. The above experimentation is made via this line: 
<img width="620" alt="Screenshot 2023-10-31 at 20 41 44" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/7c57b71e-fff6-40bd-a739-5232af23ee64">
And fortunately, the serialization is working properly:
<img width="582" alt="Screenshot 2023-10-31 at 20 49 29" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/3f1fa54a-900f-4998-b16e-c7a66e5336e1">
