### PR TITLE
Fix bug of person index change after edit via sorting person

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -31,7 +31,7 @@ public class FindCommand extends Command {
         this.trimmedArgs = trimmedArgs;
     }
 
-    @Override
+    @Override @SuppressWarnings("unchecked")
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         switch (model.getState()) {

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -94,4 +94,14 @@ public class Name extends ListEntryField {
         }
     }
 
+    public int compareTo(Name n) {
+        if (this == DEFAULT_NAME) {
+            return 1;
+        } else if (n == DEFAULT_NAME) {
+            return -1;
+        } else {
+            return fullName.compareTo(n.fullName);
+        }
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -94,6 +94,9 @@ public class Name extends ListEntryField {
         }
     }
 
+    /**
+     * Compares this name to another name.
+     */
     public int compareTo(Name n) {
         if (this == DEFAULT_NAME) {
             return 1;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -191,4 +191,8 @@ public class Person extends ListEntry<Person> {
                 subjects.getSubjectSetClone(), tags.getTagSetClone(), remark.clone());
     }
 
+    int compareTo(Person p) {
+        return name.compareTo(p.name);
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -53,6 +53,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+        internalList.sort(Person::compareTo);
     }
 
     /**
@@ -73,6 +74,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
+        internalList.sort(Person::compareTo);
     }
 
     /**
@@ -84,11 +86,13 @@ public class UniquePersonList implements Iterable<Person> {
         if (!internalList.remove(toRemove)) {
             throw new PersonNotFoundException();
         }
+        internalList.sort(Person::compareTo);
     }
 
     public void setPersons(UniquePersonList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        internalList.sort(Person::compareTo);
     }
 
     /**
@@ -102,6 +106,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+        internalList.sort(Person::compareTo);
     }
 
     /**


### PR DESCRIPTION
Sort the person list by their name, so that the newly added/ edited person is not at the end of the list.
Also add suppress uncheck tag to findCommand