### PR TITLE
Fix bug of show not updated after edit, add, delete

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AbstractEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AbstractEditCommand.java
@@ -31,6 +31,7 @@ public abstract class AbstractEditCommand<T extends ListEntry<? extends T>> exte
     protected Predicate<T> hasClashWith;
     protected Consumer<T> deleteMethod;
     protected Consumer<T> addMethod;
+    protected Consumer<T> showMethod;
 
     /**
      * Pass in index to indicate which entry to edit
@@ -66,6 +67,7 @@ public abstract class AbstractEditCommand<T extends ListEntry<? extends T>> exte
         init();
         editFields();
         validateEditedAndWriteBack();
+        showMethod.accept(edited);
         return new CommandResult("Edited : " + edited.toString());
     }
     /**

--- a/src/main/java/seedu/address/logic/commands/AbstractEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AbstractEditCommand.java
@@ -67,6 +67,7 @@ public abstract class AbstractEditCommand<T extends ListEntry<? extends T>> exte
         init();
         editFields();
         validateEditedAndWriteBack();
+        model.resetAllShowFields();
         showMethod.accept(edited);
         return new CommandResult("Edited : " + edited.toString());
     }

--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -30,6 +30,7 @@ public class AddLessonCommand extends Command {
         }
 
         model.addLesson(lesson);
+        model.showLesson(lesson);
         return new CommandResult(String.format("New lesson added: " + lesson.toString()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLessonCommand.java
@@ -28,8 +28,8 @@ public class AddLessonCommand extends Command {
             throw new CommandException("Lesson already exists in the specified time slot: "
                     + clashingLesson.toString());
         }
-
         model.addLesson(lesson);
+        model.resetAllShowFields();
         model.showLesson(lesson);
         return new CommandResult(String.format("New lesson added: " + lesson.toString()));
     }

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -81,6 +81,7 @@ public class AddPersonCommand extends Command {
             model.addLesson(lesson);
         }
         model.addPerson(toAdd);
+        model.showPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -81,6 +81,7 @@ public class AddPersonCommand extends Command {
             model.addLesson(lesson);
         }
         model.addPerson(toAdd);
+        model.resetAllShowFields();
         model.showPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -39,6 +39,10 @@ public class DeleteLessonCommand extends Command {
 
         Lesson lessonToDelete = lastShownList.get(targetIndex - 1);
         model.deleteLesson(lessonToDelete);
+        Lesson currentLesson = model.getCurrentlyDisplayedLesson();
+        if (currentLesson != null && currentLesson.equals(lessonToDelete)) {
+            model.showLesson(null);
+        }
         return new CommandResult(String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete.toString()));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -46,6 +46,10 @@ public class DeletePersonCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex - 1);
         model.deletePerson(personToDelete);
+        Person currentPerson = model.getCurrentlyDisplayedPerson();
+        if (currentPerson != null && currentPerson.equals(personToDelete)) {
+            model.showPerson(null);
+        }
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLessonCommand.java
@@ -28,6 +28,7 @@ public class EditLessonCommand extends AbstractEditCommand<Lesson> {
         hasClashWith = model::hasLessonClashWith;
         deleteMethod = model::deleteLesson;
         addMethod = model::addLesson;
+        showMethod = model::showLesson;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -58,6 +58,7 @@ public class EditPersonCommand extends AbstractEditCommand<Person> {
         hasClashWith = model::hasPersonClashWith;
         deleteMethod = model::deletePerson;
         addMethod = model::addPerson;
+        showMethod = model::showPerson;
     }
 
 

--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -7,6 +7,7 @@ import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.state.State;
 
 /**
  * Links a student to a lesson
@@ -46,6 +47,12 @@ public class LinkCommand extends Command {
             Person person = personSet.iterator().next();
             Lesson lesson = lessonSet.iterator().next();
             model.linkWith(person, lesson);
+            State state = model.getState();
+            if (state == State.STUDENT && model.getCurrentlyDisplayedPerson().equals(person)) {
+                model.showPerson(person);
+            } else if (state == State.SCHEDULE && model.getCurrentlyDisplayedLesson().equals(lesson)) {
+                model.showLesson(lesson);
+            }
             return new CommandResult("Linked " + person.getName() + " to " + lesson.getName());
         }
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -243,7 +243,7 @@ public class ModelManager implements Model {
 
     @Override
     public void showPerson(Person person) {
-        requireNonNull(person);
+        //requireNonNull(person);
         if (ui != null) {
             currentShowingPerson = person;
             ui.showPersonDetails(person);
@@ -252,7 +252,7 @@ public class ModelManager implements Model {
 
     @Override
     public void showLesson(Lesson lesson) {
-        requireNonNull(lesson);
+        //requireNonNull(lesson);
         if (ui != null) {
             currentShowingLesson = lesson;
             ui.showLessonDetails(lesson);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -268,6 +268,10 @@ public class MainWindow extends UiPart<Stage> {
      * @param person The person to show the details of.
      */
     public void handleShowPerson(Person person) {
+        if (person == null) {
+            studentDetailList.setVisible(false);
+            return;
+        }
         studentDetailList.setVisible(true);
         studentDetailListPanel.setPersonDetails(person, model);
     }
@@ -278,6 +282,10 @@ public class MainWindow extends UiPart<Stage> {
      * @param lesson The lesson to show the details of.
      */
     public void handleShowLesson(Lesson lesson) {
+        if (lesson == null) {
+            lessonDetailList.setVisible(false);
+            return;
+        }
         lessonDetailList.setVisible(true);
         lessonDetailListPanel.setLessonDetails(lesson, model);
     }

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -214,7 +214,6 @@ public class AddPersonCommandTest {
         }
         @Override
         public void showPerson(Person personToShow) {
-            throw new AssertionError("This method should not be called.");
         }
         @Override
         public void linkUi(Ui ui) {


### PR DESCRIPTION
Fix this bug before demo;

Now after add command, the newly added person/lesson will be shown; after the edit command, the shown entry will be updated; after the delete command, if the current shown entry is deleted, nothing will be shown.
Add:
<img width="1512" alt="Screenshot 2023-11-01 at 09 14 23" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/2d03f54a-2778-469e-8150-533065715259">
<img width="1512" alt="Screenshot 2023-11-01 at 09 14 26" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/5f4dd3e0-9997-460e-9380-cc5e31067323">

Edit:
"edit 1 -name new name" produces
<img width="1512" alt="Screenshot 2023-11-01 at 09 14 08" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/f0bf89e2-6bf2-417a-bdc0-8028aaff67fe">

Delete:
<img width="1512" alt="Screenshot 2023-11-01 at 09 17 10" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/70c3191c-5c90-4e94-a78d-a6073107e6c1">
<img width="1512" alt="Screenshot 2023-11-01 at 09 17 14" src="https://github.com/AY2324S1-CS2103T-T11-3/tp/assets/121547057/0679ad93-1689-4050-8050-8c6c594b6324">
