### PR TITLE
Removed the task done status from a task

### DIFF
--- a/src/main/java/seedu/address/model/lessons/Task.java
+++ b/src/main/java/seedu/address/model/lessons/Task.java
@@ -200,6 +200,13 @@ public class Task extends ListEntryField {
         return Objects.hash(description);
     }
 
+    /**
+     * Serializes the task into a string for storage.
+     * @return serialized string
+     */
+    public String serialize() {
+        return (this.isDone ? "+" : "-") + this.description;
+    }
 
     /**
      * Returns the String representation of the task.
@@ -208,7 +215,7 @@ public class Task extends ListEntryField {
      */
     @Override
     public String toString() {
-        return (this.isDone ? "+" : "-") + this.description;
+        return this.description;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -29,7 +29,7 @@ public class JsonAdaptedTask {
      * Converts a given {@code Task} into this class for Jackson use.
      */
     public JsonAdaptedTask(Task source) {
-        descriptionWithStatus = source.toString();
+        descriptionWithStatus = source.serialize();
     }
 
     @JsonValue

--- a/src/test/java/seedu/address/model/lessons/TaskTest.java
+++ b/src/test/java/seedu/address/model/lessons/TaskTest.java
@@ -85,8 +85,14 @@ public class TaskTest {
 
     @Test
     public void toStringMethod() {
-        String expected = (TASK_1.isDone() ? "+" : "-") + TASK_1.getDescription();
+        String expected = TASK_1.getDescription();
         assertEquals(expected, TASK_1.toString());
+    }
+
+    @Test
+    public void serializeMethod() {
+        String expected = "-" + TASK_1.getDescription();
+        assertEquals(expected, TASK_1.serialize());
     }
 
     @Test


### PR DESCRIPTION
The isDone flag is still in the class, but now the `toString` method has been replaced with a `serialize` method.

Can still be implemented in future releases.