### PR TITLE
PED Bug Fixes: #196, #201, #214

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -441,9 +441,9 @@ Please use show lessonIndex before deleting task!
 The find command has different behaviours depending on the current list:
 
 1. In `SCHEDULE` list:
-    - Finds lessons whose names are made up of the given search keyword.
+    - Finds lessons whose names are made up of the given search string.
 2. In `STUDENTS` list:
-    - Finds students whose names are made up of the given search keyword.
+    - Finds students whose names are made up of the given search string.
 3. In `TASKS` list:
     - Find tasks by name/description is disabled. 
     - Tasks can be found based on the lesson (find lesson by name) and `show` lesson to see task list of the lesson.
@@ -453,13 +453,13 @@ Format: `find KEYWORD`
 1. In `SCHEDULE` list:
     * The search is case-insensitive. e.g `lesson` will match `Lesson`
     * Only the name is searched.
-    * Lessons matching part of the keyword will be returned (i.e. `OR` search).
-      e.g. `Lesson Chem` will return `Lesson Chemistry`, `Bishan Lesson Chem`
+    * Lessons matching part of the search string will be returned.
+      e.g. Both `Lesson Chem` and `sson Che` will return `Lesson Chemistry`, `Bishan Lesson Chem`
 
 2. In `STUDENTS` list:
     * The search is case-insensitive. e.g `hans` will match `Hans`
     * Only the name is searched.
-    * Persons matching part of the keyword will be returned (i.e. `OR` search).
+    * Persons matching part of the search string will be returned.
       e.g. `Hans` will return `Hanso Gruber`, `Lee Hansel`
 
 Success Output:
@@ -471,9 +471,7 @@ Success Output:
 ```
 3 persons listed!
 ```
-
-
-Failure Output:
+These are also counted as success outputs, since they can be a result of finding a valid search string:
 * In `SCHEDULE` list:
 ```
 0 lessons listed!
@@ -481,6 +479,14 @@ Failure Output:
 * In `STUDENTS` list:
 ```
 0 persons listed!
+```
+
+Failure Output:
+```
+Invalid command format! 
+find: Finds all persons or lesson whose names contains the specified search string (case-insensitive) and displays them as a list with index numbers.
+Parameter: SEARCH_STRING
+Example: find alex yeoh
 ```
 
 ### Exiting the program : `exit`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -217,6 +217,7 @@ Format: `addPerson -name NAME [-phone PHONE_NUMBER] [-email EMAIL] [-address ADD
 - For flags that can take multiple values (eg. -subject, -tag), separate the values with commas.
 - Subjects can only be MATHEMATICS, PHYSICS, BIOLOGY, CHEMISTRY or ENGLISH.
 - Tags must be alphanumeric. '-', ',' and spaces are not allowed.
+- Duplicate phone numbers are allowed, since it is possible for 2 children to use their parent's number.
 </box>
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -19,6 +19,8 @@ public class ClearCommand extends Command {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
         model.setScheduleList(new ScheduleList());
+        model.showPerson(null);
+        model.showLesson(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,10 +19,10 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons or lesson whose names contain "
-            + "any ofthe specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons or lesson whose names contains "
+            + "the specified search string (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameter: SEARCH_STRING\n"
+            + "Example: " + COMMAND_WORD + " alex yeoh";
 
     private Predicate predicate;
     private final String trimmedArgs;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -296,7 +296,6 @@ public class ModelManager implements Model {
 
     @Override
     public void showPerson(Person person) {
-        //requireNonNull(person);
         if (ui != null) {
             currentShowingPerson = person;
             ui.showPersonDetails(person);
@@ -305,7 +304,6 @@ public class ModelManager implements Model {
 
     @Override
     public void showLesson(Lesson lesson) {
-        //requireNonNull(lesson);
         if (ui != null) {
             currentShowingLesson = lesson;
             ui.showLessonDetails(lesson);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -28,30 +28,29 @@ import seedu.address.model.tag.Tag;
  */
 public class SampleDataUtil {
     public static final String SAMPLE_SCHEDULE = "Mon 1200 1400 weekly";
-    public static final Remark EMPTY_REMARK = new Remark("");
 
     public static Person[] getSamplePersons() {
         try {
             return new Person[] {
                 new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                             new Address("Blk 30 Geylang Street 29, #06-40"), getSubjectSet("CHEMISTRY", "BIOLOGY"),
-                            getTagSet("friends"), EMPTY_REMARK),
+                            getTagSet("friends"), Remark.DEFAULT_REMARK),
                 new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                             new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                             getSubjectSet("English", "MATHEMATICS"),
-                            getTagSet("colleagues", "friends"), EMPTY_REMARK),
+                            getTagSet("colleagues", "friends"), Remark.DEFAULT_REMARK),
                 new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                             new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), getSubjectSet("Chemistry", "PHYSICS"),
-                            getTagSet("neighbours"), EMPTY_REMARK),
+                            getTagSet("neighbours"), Remark.DEFAULT_REMARK),
                 new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                             new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), getSubjectSet("Biology"),
-                            getTagSet("family"), EMPTY_REMARK),
+                            getTagSet("family"), Remark.DEFAULT_REMARK),
                 new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                             new Address("Blk 47 Tampines Street 20, #17-35"), getSubjectSet("English", "MATHEMATICS"),
-                            getTagSet("classmates"), EMPTY_REMARK),
+                            getTagSet("classmates"), Remark.DEFAULT_REMARK),
                 new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                             new Address("Blk 45 Aljunied Street 85, #11-31"), getSubjectSet("Chemistry"),
-                            getTagSet("colleagues"), EMPTY_REMARK)
+                            getTagSet("colleagues"), Remark.DEFAULT_REMARK)
             };
         } catch (ParseException e) {
             Logger logger = Logger.getLogger(SampleDataUtil.class.getName());

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -14,17 +15,10 @@ public class ClearCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertNull(model.getCurrentlyDisplayedPerson());
+        assertNull(expectedModel.getCurrentlyDisplayedPerson());
+        assertNull(model.getCurrentlyDisplayedLesson());
+        assertNull(expectedModel.getCurrentlyDisplayedLesson());
     }
-    // To retest with another way - creates new model everytime due to change
-    // in implementation PR #121!
-    /*@Test
-    public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(),
-                getTypicalScheduleList());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(),
-                getTypicalScheduleList());
-        expectedModel.setAddressBook(new AddressBook());
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
-    }*/
 
 }


### PR DESCRIPTION
Fixes #196 
Duplicate phone numbers are allowed, since it is possible for 2 children to use their parent's number.

Fixes #201
Default SampleDataUtil had empty remarks instead of default remarks, updated now.

Fixes #214 
* Fix find command error message that mentions keywords, but actual command takes in the entire string as one keyword
* Fix UG Find command to say search string rather than keyword, since the user can type 'alex yeoh`, which is not a keyword but 2 keywords. It is rather a search string.
* Changed 0 lessons listed! and 0 persons listed! to be success outputs, since they can be a result of finding a valid search string. A failure output arises from an invalid/empty search string.

Fixes #215 
* Modify clear command so that person or lesson details are hidden after clear command execution
* Add test case to verify no currently showing person and lesson after clear command execution