### PR TITLE
Fix Lesson clash detector

### DIFF
--- a/src/main/java/seedu/address/model/lessons/Lesson.java
+++ b/src/main/java/seedu/address/model/lessons/Lesson.java
@@ -274,15 +274,17 @@ public class Lesson extends ListEntry<Lesson> {
 
     /**
      * Returns true if both lessons have the same identity and data fields.
+     *
+     * Conditions for lessons to clash:
+     * #1 same day
+     * #2 LessonA start time before or at LessonB end time
+     * #3 LessonA end time after or at LessonB start time
      * @param otherLesson The other lesson to compare with
      * @return true if the lessons clash
      */
     public boolean isClashWith(Lesson otherLesson) {
         requireAllNonNull(otherLesson);
         if (otherLesson == this) {
-            return true;
-        }
-        if (this.name.equals(otherLesson.getName())) {
             return true;
         }
         if (this.day == Day.DEFAULT_DAY || otherLesson.getDay() == Day.DEFAULT_DAY) {

--- a/src/main/java/seedu/address/model/lessons/Lesson.java
+++ b/src/main/java/seedu/address/model/lessons/Lesson.java
@@ -279,6 +279,9 @@ public class Lesson extends ListEntry<Lesson> {
      * #1 same day
      * #2 LessonA start time before or at LessonB end time
      * #3 LessonA end time after or at LessonB start time
+     *
+     * Examples
+     * 14:00 - 16:00 does not clash with 16:00 - 18:00
      * @param otherLesson The other lesson to compare with
      * @return true if the lessons clash
      */

--- a/src/test/java/seedu/address/model/lessons/LessonTest.java
+++ b/src/test/java/seedu/address/model/lessons/LessonTest.java
@@ -1,11 +1,51 @@
 package seedu.address.model.lessons;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
 public class LessonTest {
+    private TaskList taskList = new TaskList();
     @Test
-    public void lesson_clashWithItself_true() {
-        TaskList taskList = new TaskList();
-        Lesson lesson1 = new Lesson()
+    public void clash_withItself_true() throws ParseException {
+
+        Lesson lesson1 = new Lesson("Test name", "10:00", "12:00", "20", "Chemistry",
+                taskList);
+        assertTrue(lesson1.isClashWith(lesson1));
     }
+
+    @Test
+    public void doesNotClash_withNonOverlapping_true() throws ParseException {
+        Lesson lesson1 = new Lesson("Test name", "10:00", "12:00", "20", "Chemistry",
+                taskList);
+        Lesson lesson2 = new Lesson("Test name", "10:00", "12:00", "23", "Chemistry",
+                taskList);
+
+        assertFalse(lesson1.isClashWith(lesson2));
+    }
+
+    @Test
+    public void clash_withOverlappingLesson_true() throws ParseException {
+        Lesson lesson1 = new Lesson("Test name", "10:00", "12:00", "20", "Chemistry",
+                taskList);
+        Lesson lesson2 = new Lesson("Test name", "11:00", "13:00", "20", "Chemistry",
+                taskList);
+
+        assertTrue(lesson1.isClashWith(lesson2));
+    }
+
+    @Test
+    public void doesNotClash_startTimeEqualsEndTime_true() throws ParseException {
+        Lesson lesson1 = new Lesson("Test name", "10:00", "12:00", "20", "Chemistry",
+                taskList);
+        Lesson lesson2 = new Lesson("Test name", "12:00", "13:00", "20", "Chemistry",
+                taskList);
+
+        assertFalse(lesson1.isClashWith(lesson2));
+    }
+
 }

--- a/src/test/java/seedu/address/model/lessons/LessonTest.java
+++ b/src/test/java/seedu/address/model/lessons/LessonTest.java
@@ -1,0 +1,11 @@
+package seedu.address.model.lessons;
+
+import org.junit.jupiter.api.Test;
+
+public class LessonTest {
+    @Test
+    public void lesson_clashWithItself_true() {
+        TaskList taskList = new TaskList();
+        Lesson lesson1 = new Lesson()
+    }
+}


### PR DESCRIPTION
Fixes the lesson clash detector.

Previously the lessons clashed when the names were the same, even if the dates were different.

Fixes issues:
- #212 