### PR TITLE
Fixed address and phone from being erased when editing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -67,8 +67,8 @@ public class EditPersonCommand extends AbstractEditCommand<Person> {
     @Override
     protected void setNonDefaultFields() throws CommandException {
         edited.setPhoneIfNotDefault(editDescriptor.getPhone());
-        edited.setEmail(editDescriptor.getEmail());
-        edited.setAddress(editDescriptor.getAddress());
+        edited.setEmailIfNotDefault(editDescriptor.getEmail());
+        edited.setAddressIfNotDefault(editDescriptor.getAddress());
         edited.setSubjectsIfNotDefault(editDescriptor.getSubjects());
     }
 


### PR DESCRIPTION
Fixes the edit command to not erase fields if not set. Previously, editing a person without specifying the address field would delete it, and same goes for the email field.

Also fixes the edit command succeeding when no fields are entered.

Fixes:
- #191 
- #195 