### PR TITLE
Add delete lesson command parser test

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLessonCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.lessons.Lesson;
@@ -27,6 +28,10 @@ public class DeleteLessonCommand extends Command {
         this.targetIndex = targetIndex;
     }
 
+    public DeleteLessonCommand(Index targetIndex) {
+        this.targetIndex = targetIndex.getOneBased();
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -48,4 +53,20 @@ public class DeleteLessonCommand extends Command {
         }
         return new CommandResult(String.format(MESSAGE_DELETE_LESSON_SUCCESS, lessonToDelete.toString()));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteLessonCommand)) {
+            return false;
+        }
+
+        DeleteLessonCommand otherDeleteLessonCommand = (DeleteLessonCommand) other;
+        return targetIndex == otherDeleteLessonCommand.targetIndex;
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteLessonCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.DeleteLessonCommand;
-import seedu.address.logic.commands.DeletePersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -20,7 +19,7 @@ public class DeleteLessonCommandParser implements Parser<DeleteLessonCommand> {
         try {
             index = TypeParsingUtil.parseNum(args.trim());
         } catch (ParseException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteLessonCommand.MESSAGE_USAGE));
         }
         return new DeleteLessonCommand(index);
     }

--- a/src/test/java/seedu/address/logic/commands/AddLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLessonCommandTest.java
@@ -44,4 +44,3 @@ class AddLessonCommandTest {
         }
     }
 }
-

--- a/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LESSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LESSON;
+import static seedu.address.testutil.TypicalLessons.getTypicalScheduleList;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+class DeleteLessonCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(),
+            getTypicalScheduleList());
+
+    @Test
+    public void equals() {
+        DeleteLessonCommand deleteFirstCommand = new DeleteLessonCommand(INDEX_FIRST_LESSON);
+        DeleteLessonCommand deleteSecondCommand = new DeleteLessonCommand(INDEX_SECOND_LESSON);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteLessonCommand deleteFirstCommandCopy = new DeleteLessonCommand(INDEX_FIRST_LESSON);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteLessonCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LESSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteLessonCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteLessonCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the TypeParserUtilTest.
+ */
+
+class DeleteLessonCommandParserTest {
+    private DeleteLessonCommandParser parser = new DeleteLessonCommandParser();
+    @Test
+    public void parse_validArgs_returnsDeleteLessonCommand() {
+        DeleteLessonCommand c = new DeleteLessonCommand(INDEX_FIRST_LESSON);
+        assertParseSuccess(parser, "1", new DeleteLessonCommand(INDEX_FIRST_LESSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteLessonCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_LESSON = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_LESSON = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_LESSON = Index.fromOneBased(3);
+
 }


### PR DESCRIPTION
1. Add tests for delete lesson command parser Fixes #231 
2. Incorrect delete lesson message displayed, made the changes accordingly Fixes #239 
