### PR TITLE
Improve code quality

### DIFF
--- a/src/main/java/seedu/address/logic/parser/TypeParsingUtil.java
+++ b/src/main/java/seedu/address/logic/parser/TypeParsingUtil.java
@@ -79,25 +79,26 @@ public class TypeParsingUtil {
      * Parses the index from the input string
      */
     public static Integer parseIndex(String input, boolean isOptional) throws ParseException {
-        Pattern p1 = Pattern.compile(STARTING_WITH_ONE_TO_FIVE_DIGITS);
-        Pattern p2 = Pattern.compile(RegularExpressionUtil.STARTING_WITH_MORE_THAN_FIVE_DIGITS);
-        Pattern p3 = Pattern.compile(RegularExpressionUtil.STARTING_WITH_NEGATIVE_NUMBER);
-        Pattern p4 = Pattern.compile(RegularExpressionUtil.ABUSING_INDEX_WITH_DECIMAL_OR_DIVISION);
-        Matcher m = p1.matcher(input);
-        if (p4.matcher(input).find()) {
+        Pattern validIndexPattern = Pattern.compile(STARTING_WITH_ONE_TO_FIVE_DIGITS);
+        Pattern tooManyNumberPattern = Pattern.compile(RegularExpressionUtil.STARTING_WITH_MORE_THAN_FIVE_DIGITS);
+        Pattern negativeNumberPattern = Pattern.compile(RegularExpressionUtil.STARTING_WITH_NEGATIVE_NUMBER);
+        Pattern decimalOrDivisionPattern = Pattern
+                .compile(RegularExpressionUtil.ABUSING_INDEX_WITH_DECIMAL_OR_DIVISION);
+        Matcher indexMatcher = validIndexPattern.matcher(input);
+        if (decimalOrDivisionPattern.matcher(input).find()) {
             throw new InvalidInputException("Index input cannot be a decimal or fraction, allowed range: 1-99999.");
-        } else if (p2.matcher(input).find()) {
+        } else if (tooManyNumberPattern.matcher(input).find()) {
             throw new InvalidInputException("Index input is too large(allowed range: 1-99999) "
                     + "or exceeds five digits(starting zeros included)");
-        } else if (m.find()) {
-            String found = m.group(1);
+        } else if (indexMatcher.find()) {
+            String found = indexMatcher.group(1);
             int ans = parseNum(found);
             if (ans == 0) {
                 throw new InvalidInputException("Index input can not be zero, allowed range: 1-99999");
             } else {
                 return ans;
             }
-        } else if (p3.matcher(input).find()) {
+        } else if (negativeNumberPattern.matcher(input).find()) {
             throw new InvalidInputException("Index cannot be negative, allowed range: 1-99999");
         } else {
             if (isOptional) {

--- a/src/main/java/seedu/address/model/lessons/Task.java
+++ b/src/main/java/seedu/address/model/lessons/Task.java
@@ -105,7 +105,7 @@ public class Task extends ListEntryField {
      * @return Task
      * @throws ParseException if the string doesn't contain a + or - at the start.
      */
-    public static Task ofDepreciated(String task) throws ParseException {
+    public static Task deserialize(String task) throws ParseException {
         // parse the task
         checkArgument(isValidEncodedTask(task));
         String description = task.substring(1);

--- a/src/main/java/seedu/address/model/lessons/TaskList.java
+++ b/src/main/java/seedu/address/model/lessons/TaskList.java
@@ -140,7 +140,7 @@ public class TaskList extends ListEntryField implements Iterable<Task> {
         TaskList taskList = new TaskList();
         for (JsonAdaptedTask taskString : tasks) {
             // parse the task
-            Task task = deserialize(Task.DEFAULT_TASK, Task::ofDepreciated, taskString.getTaskName());
+            Task task = deserialize(Task.DEFAULT_TASK, Task::deserialize, taskString.getTaskName());
             taskList.add(task);
         }
         return taskList;

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -46,7 +46,7 @@ public class JsonAdaptedTask {
         if (!Task.isValidEncodedTask(descriptionWithStatus)) {
             throw new IllegalValueException(Task.DECODED_CONSTRAINTS);
         }
-        return deserialize(Task.DEFAULT_TASK, Task::ofDepreciated, descriptionWithStatus);
+        return deserialize(Task.DEFAULT_TASK, Task::deserialize, descriptionWithStatus);
     }
 
 }

--- a/src/test/java/seedu/address/model/lessons/TaskTest.java
+++ b/src/test/java/seedu/address/model/lessons/TaskTest.java
@@ -100,13 +100,13 @@ public class TaskTest {
         Task doneTask = new Task("Sample", true);
         String doneTaskString = "+Sample";
 
-        Task parsedDoneTask = Task.ofDepreciated(doneTaskString);
+        Task parsedDoneTask = Task.deserialize(doneTaskString);
         assertEquals(doneTask, parsedDoneTask);
     }
 
     @Test
     public void of_task_throwsParseError() {
         String failedTaskString = "Sample";
-        assertThrows(IllegalArgumentException.class, () -> Task.ofDepreciated(failedTaskString));
+        assertThrows(IllegalArgumentException.class, () -> Task.deserialize(failedTaskString));
     }
 }


### PR DESCRIPTION
Give the pattern in typeParsing util proper names.
Rename "ofDepreciated" to "deserialize". Was given the name "ofDepreciated" as it was designed to support parsing "isMarked" value in task. But since we are not to change it, so rename to "deserialize".